### PR TITLE
Added $Element.prototype.prepare()

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ The issue with the above is that each call to `text()` modifies the actual bluep
 
 ### Using `prepare()` to dynamically change the generated DOM element
 
-What we can do instead is create a slightly different version of this code, using `prepare()`. This method takes a callback function as its sole argument, which then allows you to modify each "instance" of the blueprint without introducing side-effects to the other elements.
+What we can do instead is create a slightly different version of this code, using `prepare()`. This method takes a callback function as its sole argument, which then allows you to modify each "instance" of the blueprint without introducing side-effects to the other elements. You can even add multiple `prepare()` calls to a blueprint!
 
 Here's how we could rewrite the above snippet using prepare:
 
@@ -229,7 +229,6 @@ Here's how we could rewrite the above snippet using prepare:
 // This is dangerous and could introduce bugs to your code! Try out this example to see what strange side-effects you get
 var cardBlueprint = $new('.card').prepare(function($this, props) {
 	$this.text(props.cardText);
-	return $this;
 });
 
 document.body.appendChild(cardBlueprint.element({

--- a/README.md
+++ b/README.md
@@ -226,7 +226,6 @@ What we can do instead is create a slightly different version of this code, usin
 Here's how we could rewrite the above snippet using prepare:
 
 ```js
-// This is dangerous and could introduce bugs to your code! Try out this example to see what strange side-effects you get
 var cardBlueprint = $new('.card').prepare(function($this, props) {
 	$this.text(props.cardText);
 });
@@ -235,12 +234,10 @@ document.body.appendChild(cardBlueprint.element({
 	cardText: 'This is a card.'
 }));
 
-cardBlueprint.text();
 document.body.appendChild(cardBlueprint.element({
 	cardText: 'This is a second card!'
 }));
 
-cardBlueprint.text();
 document.body.appendChild(cardBlueprint.element({
 	cardText: 'Three cards?!'
 }));

--- a/blueprint.js
+++ b/blueprint.js
@@ -181,7 +181,7 @@ $Element.prototype.copy = function() {
 		res.classList.push(this.classList[x]);
 	}
 	for (var k in this.attributes) {
-		res.attributes.push(this.attributes[k]);
+		res.attributes[k] = this.attributes[k];
 	}
 	for (var type in this.eventListeners) {
 		var src = this.eventListeners[type];
@@ -198,6 +198,7 @@ $Element.prototype.copy = function() {
 			res.childNodes.push(child.clone());
 		}
 	}
+	res.data = Object.assign({}, this.data);
 	// Return the copy
 	return res;
 }

--- a/blueprint.js
+++ b/blueprint.js
@@ -24,7 +24,7 @@ SOFTWARE.
 
 /*
 	Blueprint.js - a simple, small DOM templating library
-	Version 0.2.0
+	Version 0.2.1
 	Copyright (c) 2017 Ian Jones
 */
 

--- a/blueprint.js
+++ b/blueprint.js
@@ -37,6 +37,7 @@ $Element = function() {
 	this.eventListeners = new Object();
 	this.attributes = new Object();
 	this.styleData = new Object();
+	this.prepareCallbacks = new Array();
 	// For Extensibility
 	this.callbacks = new Array();
 	this.data = new Object();
@@ -198,22 +199,29 @@ $Element.prototype.copy = function() {
 			res.childNodes.push(child.clone());
 		}
 	}
-	res.data = Object.assign({}, this.data);
+	for (var x = 0, y = this.prepareCallbacks.length; x < y; ++ x) {
+		res.prepareCallbacks.push(this.prepareCallbacks[x]);
+	}
+	Object.assign(res.data, this.data);
 	// Return the copy
 	return res;
 }
 
 $Element.prototype.prepare = function(callback) {
-	this.data.prepare = callback;
+	this.prepareCallbacks.push(callback);
 	return this;
 }
 
 $Element.prototype.create =
 $Element.prototype.element = function(props) {
-	if (this.data.prepare !== undefined) {
-		return this.data.prepare(this.copy(), props)._createElement();
+	var $this = this;
+	if (this.prepareCallbacks.length > 0) {
+		$this = $this.copy();
+		for (var x = 0, y = this.prepareCallbacks.length; x < y; ++ x) {
+			$this.prepareCallbacks[x]($this, props);
+		}
 	}
-	return this._createElement();
+	return $this._createElement();
 }
 
 $Element.prototype._createElement = function() {

--- a/blueprint.js
+++ b/blueprint.js
@@ -203,8 +203,20 @@ $Element.prototype.copy = function() {
 	return res;
 }
 
+$Element.prototype.prepare = function(callback) {
+	this.data.prepare = callback;
+	return this;
+}
+
 $Element.prototype.create =
-$Element.prototype.element = function() {
+$Element.prototype.element = function(props) {
+	if (this.data.prepare !== undefined) {
+		return this.data.prepare(this.copy(), props)._createElement();
+	}
+	return this._createElement();
+}
+
+$Element.prototype._createElement = function() {
 	// Create the element
 	var $this = document.createElement(this.tagName);
 	// Set the classes

--- a/blueprint.js
+++ b/blueprint.js
@@ -215,9 +215,9 @@ $Element.prototype.prepare = function(callback) {
 $Element.prototype.create =
 $Element.prototype.element = function(props) {
 	var $this = this;
-	if (this.prepareCallbacks.length > 0) {
+	if ($this.prepareCallbacks.length > 0) {
 		$this = $this.copy();
-		for (var x = 0, y = this.prepareCallbacks.length; x < y; ++ x) {
+		for (var x = 0, y = $this.prepareCallbacks.length; x < y; ++ x) {
 			$this.prepareCallbacks[x]($this, props);
 		}
 	}

--- a/demo.css
+++ b/demo.css
@@ -1,0 +1,8 @@
+.card {
+	margin: 8px 8px 16px;
+	display: inline-block;
+	padding: 16px;
+	border-radius: 2px;
+	box-shadow: 0 1px 8px 0 rgba(0, 0, 0, 0.31);
+	list-style: none;
+}

--- a/demo.js
+++ b/demo.js
@@ -1,4 +1,4 @@
-document.addEventListener("DOMContentLoaded", function() {
+document.addEventListener('DOMContentLoaded', function() {
 	document.body.appendChild($frag(
 		$new('h1')
 			.text('Add multiple elements easily')
@@ -17,8 +17,8 @@ document.addEventListener("DOMContentLoaded", function() {
 			listStyle: 'none'
 		})
 		.children(
-			$new('li').text("Create lists"),
-			$new('li').text("And style them"),
+			$new('li').text('Create lists'),
+			$new('li').text('And style them'),
 			$new('li').children(
 				'Or create ',
 				$new('a').text('links')

--- a/demo.js
+++ b/demo.js
@@ -39,7 +39,6 @@ document.addEventListener('DOMContentLoaded', function() {
 				var name = props.name;
 				$this.text(name);
 				$this.attr('data-name', name);
-				return $this;
 			});
 	
 	document.body.appendChild($frag(

--- a/demo.js
+++ b/demo.js
@@ -31,4 +31,20 @@ document.addEventListener('DOMContentLoaded', function() {
 		)
 		.element()
 	);
+	
+	var CardBlueprint =
+		$new('.card')
+			.text('My name is ')
+			.prepare(($this, props) => {
+				var name = props.name;
+				$this.text(name);
+				$this.attr('data-name', name);
+				return $this;
+			});
+	
+	document.body.appendChild($frag(
+		$new('h2').text('Create re-usable blueprints and pass in props to create dynamic elements'),
+		CardBlueprint.element({ name: 'Ian' }),
+		CardBlueprint.element({ name: 'Bret' }),
+	));
 });


### PR DESCRIPTION
Under the hood, if a callback has been given via `prepare()`, the `element()` function will create a copy of the `$Element` and pass that onto the callback. The callback then allows the user to make modifications to the clone, without affecting the original blueprint.